### PR TITLE
Increase .net to 4.7.2

### DIFF
--- a/Tether/App.config
+++ b/Tether/App.config
@@ -3,15 +3,15 @@
     <configSections>
     <section name="nlog" type="NLog.Config.ConfigSectionHandler, NLog" />
   </configSections>
-  
+
   <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <targets>
           <target name="file" xsi:type="File" layout="[${longdate}/${pad:padding=-1:fixedLength=true:inner=${level}}/${pad:padding=3:fixedLength=true:inner=${threadid}:padCharacter=0}/${logger}] ${message} ${exception:format=ToString}" fileName="${basedir}/logs/all/logfile.${date:format=yyyyMMdd}.txt" keepFileOpen="false" encoding="iso-8859-2" archiveFileName="${basedir}/logs/all/logfile.{#}.txt" archiveEvery="Day" archiveNumbering="Date" maxArchiveFiles="90" />
-    
+
     <target name="selectiveFile" xsi:type="File" layout="${longdate} ${logger} ${level} ${message} ${exception:format=ToString}" fileName="${basedir}/logs/${level}/logfile.${date:format=yyyyMMdd}.txt" keepFileOpen="false" encoding="iso-8859-2" archiveFileName="${basedir}/logs/${level}/logfile.{#}.txt" archiveEvery="Day" archiveNumbering="Date" maxArchiveFiles="90" />
 
     <target name="console" xsi:type="ColoredConsole" layout="[${longdate}/${pad:padding=-1:fixedLength=true:inner=${level}}/${pad:padding=3:fixedLength=true:inner=${threadid}:padCharacter=0}/${logger}] ${message} ${exception:format=ToString}" />
-    
+
 
     </targets>
     <rules>
@@ -20,11 +20,11 @@
       <logger name="*" minLevel="Trace" appendTo="selectiveFile" />
     </rules>
   </nlog>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
+    <startup>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
   <runtime>
-    <appDomainResourceMonitoring enabled="true"/> 
+    <appDomainResourceMonitoring enabled="true"/>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />


### PR DESCRIPTION
This PR increases the required .NET version to 4.7.2 per [recommendations ](https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls)

I've tested the artifact from the build and had no issues on a Win 2008R2 VM - https://ci.appveyor.com/project/shurl/tether/build/2.0.2 

@carlosperello please can you review? 