### PR TITLE
Default to log errors only

### DIFF
--- a/Tether/App.config
+++ b/Tether/App.config
@@ -3,28 +3,28 @@
     <configSections>
     <section name="nlog" type="NLog.Config.ConfigSectionHandler, NLog" />
   </configSections>
-  
+
   <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <targets>
           <target name="file" xsi:type="File" layout="[${longdate}/${pad:padding=-1:fixedLength=true:inner=${level}}/${pad:padding=3:fixedLength=true:inner=${threadid}:padCharacter=0}/${logger}] ${message} ${exception:format=ToString}" fileName="${basedir}/logs/all/logfile.${date:format=yyyyMMdd}.txt" keepFileOpen="false" encoding="iso-8859-2" archiveFileName="${basedir}/logs/all/logfile.{#}.txt" archiveEvery="Day" archiveNumbering="Date" maxArchiveFiles="90" />
-    
+
     <target name="selectiveFile" xsi:type="File" layout="${longdate} ${logger} ${level} ${message} ${exception:format=ToString}" fileName="${basedir}/logs/${level}/logfile.${date:format=yyyyMMdd}.txt" keepFileOpen="false" encoding="iso-8859-2" archiveFileName="${basedir}/logs/${level}/logfile.{#}.txt" archiveEvery="Day" archiveNumbering="Date" maxArchiveFiles="90" />
 
     <target name="console" xsi:type="ColoredConsole" layout="[${longdate}/${pad:padding=-1:fixedLength=true:inner=${level}}/${pad:padding=3:fixedLength=true:inner=${threadid}:padCharacter=0}/${logger}] ${message} ${exception:format=ToString}" />
-    
+
 
     </targets>
     <rules>
-      <logger name="*" minLevel="Trace" appendTo="console" />
-      <logger name="*" minLevel="Trace" appendTo="file" />
-      <logger name="*" minLevel="Trace" appendTo="selectiveFile" />
+      <logger name="*" minLevel="Error" appendTo="console" />
+      <logger name="*" minLevel="Error" appendTo="file" />
+      <logger name="*" minLevel="Error" appendTo="selectiveFile" />
     </rules>
   </nlog>
-    <startup> 
+    <startup>
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
     </startup>
   <runtime>
-    <appDomainResourceMonitoring enabled="true"/> 
+    <appDomainResourceMonitoring enabled="true"/>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />


### PR DESCRIPTION
This PR updates the default logging options to log on errors only, instead of logging everything.

The readme has been updated in the update-readme branch to reflect this change. 

@carlosperello please can you review? 